### PR TITLE
docs: add Netlify and Vercel deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,38 @@ Git
 
 ### 🚢 Deployment
 
+This project supports deployment on both **Netlify** and **Vercel**.
+
+---
+
+#### Deploying to Netlify
+
+1. Push your forked repository to GitHub
+2. Go to [netlify.com](https://netlify.com) and click **"Add new site" → "Import an existing project"**
+3. Connect your GitHub account and select the repository
+4. Netlify will auto-detect the settings from `netlify.toml`:
+   - **Build command:** `npm install`
+   - **Publish directory:** `public`
+   - **Functions directory:** `netlify/functions`
+5. Add your environment variables under **Site settings → Environment variables**:
+6. Click **"Deploy site"**
+
+> API calls to `/api/*` are automatically redirected to Netlify Functions via the config.
+
+---
+
+#### Deploying to Vercel
+
+1. Push your forked repository to GitHub
+2. Go to [vercel.com](https://vercel.com) and click **"Add New Project"**
+3. Import your GitHub repository
+4. Vercel will auto-detect the settings from `vercel.json`
+5. Add your environment variables under **Project Settings → Environment Variables**:
+6. Click **"Deploy"**
+
+> API requests to `/api/*` are handled by `api/index.js` as a serverless function, with a max duration of 30 seconds.
+
+
 ## 🌐 Live Demo
 
 **🔗 [View Live Demo](https://educratenoteshub.vercel.app/)**


### PR DESCRIPTION
## Summary
Fixes #54 — fills in the empty Deployment section under the Developer docs.

## What I changed
Added step-by-step deployment instructions for both Netlify and Vercel 
based on the existing `netlify.toml` and `vercel.json` config files 
already in the repository.

## Why
The `### 🚢 Deployment` section heading existed in the README but had 
no content under it. New contributors or developers wanting to self-host 
the project had no guidance.

## How to verify
Open `README.md` and scroll to the **"For Developers"** section. 
The Deployment section now contains instructions for both platforms, 
referencing the actual config values from the repo.